### PR TITLE
feat: stop estimating gas in tests [APE-1031]

### DIFF
--- a/ape_fantom/ecosystem.py
+++ b/ape_fantom/ecosystem.py
@@ -1,15 +1,30 @@
-from typing import Optional, cast
+from typing import Dict, Optional, Type, Union, cast
 
+from ape.api import TransactionAPI
 from ape.api.config import PluginConfig
 from ape.api.networks import LOCAL_NETWORK_NAME
+from ape.exceptions import ApeException
+from ape.types import TransactionSignature
 from ape.utils import DEFAULT_LOCAL_TRANSACTION_ACCEPTANCE_TIMEOUT
 from ape_ethereum.ecosystem import Ethereum, NetworkConfig
+from ape_ethereum.transactions import (
+    AccessListTransaction,
+    DynamicFeeTransaction,
+    StaticFeeTransaction,
+    TransactionType,
+)
 
 NETWORKS = {
     # chain_id, network_id
     "opera": (250, 250),
     "testnet": (4002, 4002),
 }
+
+
+class ApeFantomError(ApeException):
+    """
+    Raised in the ape-fantom plugin.
+    """
 
 
 def _create_network_config(
@@ -43,3 +58,63 @@ class Fantom(Ethereum):
     @property
     def config(self) -> FantomConfig:  # type: ignore[override]
         return cast(FantomConfig, self.config_manager.get_config("fantom"))
+
+    def create_transaction(self, **kwargs) -> TransactionAPI:
+        """
+        Returns a transaction using the given constructor kwargs.
+        Overridden because does not support
+
+        **kwargs: Kwargs for the transaction class.
+
+        Returns:
+            :class:`~ape.api.transactions.TransactionAPI`
+        """
+
+        transaction_type = self.get_transaction_type(kwargs.get("type"))
+        kwargs["type"] = transaction_type.value
+        txn_class = _get_transaction_cls(transaction_type)
+
+        if "required_confirmations" not in kwargs or kwargs["required_confirmations"] is None:
+            # Attempt to use default required-confirmations from `ape-config.yaml`.
+            required_confirmations = 0
+            active_provider = self.network_manager.active_provider
+            if active_provider:
+                required_confirmations = active_provider.network.required_confirmations
+
+            kwargs["required_confirmations"] = required_confirmations
+
+        if isinstance(kwargs.get("chainId"), str):
+            kwargs["chainId"] = int(kwargs["chainId"], 16)
+
+        if "hash" in kwargs:
+            kwargs["data"] = kwargs.pop("hash")
+
+        if all(field in kwargs for field in ("v", "r", "s")):
+            kwargs["signature"] = TransactionSignature(
+                v=kwargs["v"],
+                r=bytes(kwargs["r"]),
+                s=bytes(kwargs["s"]),
+            )
+
+        return txn_class.parse_obj(kwargs)
+
+    def get_transaction_type(self, _type: Optional[Union[int, str, bytes]]) -> TransactionType:
+        if _type is None:
+            version = TransactionType.STATIC
+        elif not isinstance(_type, int):
+            version = TransactionType(self.conversion_manager.convert(_type, int))
+        else:
+            version = TransactionType(_type)
+        return version
+
+
+def _get_transaction_cls(transaction_type: TransactionType) -> Type[TransactionAPI]:
+    transaction_types: Dict[TransactionType, Type[TransactionAPI]] = {
+        TransactionType.STATIC: StaticFeeTransaction,
+        TransactionType.DYNAMIC: DynamicFeeTransaction,
+        TransactionType.ACCESS_LIST: AccessListTransaction,
+    }
+    if transaction_type not in transaction_types:
+        raise ApeFantomError(f"Transaction type '{transaction_type}' not supported.")
+
+    return transaction_types[transaction_type]

--- a/ape_fantom/ecosystem.py
+++ b/ape_fantom/ecosystem.py
@@ -2,9 +2,8 @@ from typing import Optional, cast
 
 from ape.api.config import PluginConfig
 from ape.api.networks import LOCAL_NETWORK_NAME
-from ape_ethereum.ecosystem import Ethereum, NetworkConfig
 from ape.utils import DEFAULT_LOCAL_TRANSACTION_ACCEPTANCE_TIMEOUT
-
+from ape_ethereum.ecosystem import Ethereum, NetworkConfig
 
 NETWORKS = {
     # chain_id, network_id

--- a/ape_fantom/ecosystem.py
+++ b/ape_fantom/ecosystem.py
@@ -3,6 +3,8 @@ from typing import Optional, cast
 from ape.api.config import PluginConfig
 from ape.api.networks import LOCAL_NETWORK_NAME
 from ape_ethereum.ecosystem import Ethereum, NetworkConfig
+from ape.utils import DEFAULT_LOCAL_TRANSACTION_ACCEPTANCE_TIMEOUT
+
 
 NETWORKS = {
     # chain_id, network_id
@@ -19,9 +21,13 @@ def _create_network_config(
     )
 
 
-def _create_local_config(default_provider: Optional[str] = None) -> NetworkConfig:
+def _create_local_config(default_provider: Optional[str] = None, **kwargs) -> NetworkConfig:
     return _create_network_config(
-        required_confirmations=0, block_time=0, default_provider=default_provider
+        required_confirmations=0,
+        default_provider=default_provider,
+        transaction_acceptance_timeout=DEFAULT_LOCAL_TRANSACTION_ACCEPTANCE_TIMEOUT,
+        gas_limit="max",
+        **kwargs,
     )
 
 

--- a/tests/test_ecosystem.py
+++ b/tests/test_ecosystem.py
@@ -3,12 +3,12 @@ from ape_ethereum.transactions import TransactionType
 
 
 def test_gas_limit(networks):
-    arbitrum = networks.arbitrum
-    assert arbitrum.config.local.gas_limit == "max"
+    fantom = networks.fantom
+    assert fantom.config.local.gas_limit == "max"
 
 
 @pytest.mark.parametrize("type", (0, "0x0"))
 def test_create_transaction(networks, type):
-    optimism = networks.fantom
-    txn = optimism.create_transaction(type=type)
+    fantom = networks.fantom
+    txn = fantom.create_transaction(type=type)
     assert txn.type == TransactionType.STATIC.value

--- a/tests/test_ecosystem.py
+++ b/tests/test_ecosystem.py
@@ -1,0 +1,14 @@
+import pytest
+from ape_ethereum.transactions import TransactionType
+
+
+def test_gas_limit(networks):
+    arbitrum = networks.arbitrum
+    assert arbitrum.config.local.gas_limit == "max"
+
+
+@pytest.mark.parametrize("type", (0, "0x0"))
+def test_create_transaction(networks, type):
+    optimism = networks.fantom
+    txn = optimism.create_transaction(type=type)
+    assert txn.type == TransactionType.STATIC.value


### PR DESCRIPTION
### What I did

Follow changes from `ape-ethereum` and stop estimating gas in tests

fixes: #

### How I did it

### How to verify it

### Checklist

- [ ] Passes all linting checks (pre-commit and CI jobs)
- [ ] New test cases have been added and are passing
- [ ] Documentation has been updated
- [ ] PR title follows [Conventional Commit](https://www.conventionalcommits.org/en/v1.0.0/) standard (will be automatically included in the changelog)
